### PR TITLE
Updated instance type

### DIFF
--- a/terraform/awsk3s01/main.tf
+++ b/terraform/awsk3s01/main.tf
@@ -107,7 +107,7 @@ module "k3s" {
   ami_id           = "ami-0149a3b1558828b26"
   assign_public_ip = true
   deployment_name  = local.deployment_name
-  instance_type    = "t4g.small"
+  instance_type    = "t3.micro"
   security_group_ids = [
     aws_security_group.cluster.id,
     aws_security_group.minecraft_bedrock.id


### PR DESCRIPTION
The instance type for the deployment has been updated to t3.micro to match the architecture of the AMI.